### PR TITLE
build: use tsup to build both CJS and ESM versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,8 +4,15 @@
     "description": "Fast and correct clip functions for HTML and plain text.",
     "main": "dist/index.js",
     "types": "dist/index.d.ts",
+    "exports": {
+        ".": {
+            "types": "./dist/index.d.ts",
+            "import": "./dist/index.js",
+            "require": "./dist/index.cjs"
+        }
+    },
     "scripts": {
-        "build": "tsc",
+        "build": "tsup",
         "lint": "eslint mod.ts src/*.ts tests/*/*.ts",
         "prepublish": "yarn build",
         "test": "jest"
@@ -15,6 +22,9 @@
         "type": "git",
         "url": "https://github.com/arendjr/text-clipper.git"
     },
+    "files": [
+        "dist"
+    ],
     "keywords": [
         "clip",
         "html",
@@ -25,6 +35,7 @@
     ],
     "license": "MIT",
     "devDependencies": {
+        "@tsconfig/node18": "^18.2.2",
         "@types/jest": "^25.2.2",
         "@typescript-eslint/eslint-plugin": "^2.33.0",
         "@typescript-eslint/parser": "^2.33.0",
@@ -36,7 +47,8 @@
         "prepush": "^3.1.11",
         "prettier": "^2.0.5",
         "ts-jest": "^25.5.1",
-        "typescript": "^3.9.2"
+        "tsup": "^7.2.0",
+        "typescript": "^5.2.2"
     },
     "prepush": {
         "tasks": [

--- a/package.json
+++ b/package.json
@@ -7,8 +7,8 @@
     "exports": {
         ".": {
             "types": "./dist/index.d.ts",
-            "import": "./dist/index.js",
-            "require": "./dist/index.cjs"
+            "import": "./dist/index.mjs",
+            "require": "./dist/index.js"
         }
     },
     "scripts": {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,4 +1,5 @@
 {
+    "extends": "@tsconfig/node18/tsconfig.json",
     "compilerOptions": {
         "allowJs": true,
         "allowSyntheticDefaultImports": true,

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -11,11 +11,5 @@ export default defineConfig({
     skipNodeModulesBundle: true,
     splitting: true,
     target: "es2017",
-    async onSuccess() {
-        const file = path.join(__dirname, './dist/index.js');
-        let code = await fsp.readFile(file, "utf8");
-        code = code.replace("exports.default =", "module.exports =");
-        code += "exports.default = module.exports;";
-        fsp.writeFile(file, code);
-    },
+    cjsInterop: true,
 });

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -1,0 +1,21 @@
+import fsp from "node:fs/promises";
+import path from "node:path";
+
+import { defineConfig } from "tsup";
+
+export default defineConfig({
+    format: ["cjs", "esm"], // generate cjs and esm files
+    entry: ["src/index.ts"],
+    clean: true, // rimraf dis
+    dts: true, // generate dts file for main module
+    skipNodeModulesBundle: true,
+    splitting: true,
+    target: "es2017",
+    async onSuccess() {
+        const file = path.join(__dirname, './dist/index.js');
+        let code = await fsp.readFile(file, "utf8");
+        code = code.replace("exports.default =", "module.exports =");
+        code += "exports.default = module.exports;";
+        fsp.writeFile(file, code);
+    },
+});


### PR DESCRIPTION
This Pull Request introduces a new build configuration that facilitates the packaging of the library in both CommonJS (CJS) and ECMAScript Module (ESM) formats. This dual format packaging ensures compatibility with a wide range of JavaScript environments including Node.js and modern browsers